### PR TITLE
Fix python3.10 compatilibity

### DIFF
--- a/_fdsend.c
+++ b/_fdsend.c
@@ -22,6 +22,7 @@
  * Corporation for National Research Initiatives; All Rights Reserved.
  */
 
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
 struct module_state {
@@ -191,7 +192,7 @@ fdsend_sendfds(PyObject *m, PyObject *args, PyObject *kw)
 	struct msghdr mh;
 	struct iovec iov;
 	int fd, r, flags = 0;
-	int msg_len;
+	Py_ssize_t msg_len;
 	PyObject *fds = Py_None;
 
 	static char *keywords[] = {"fd", "msg", "flags", "fds", 0};

--- a/_fdsend.c
+++ b/_fdsend.c
@@ -234,7 +234,8 @@ fdsend_recvfds(PyObject *m, PyObject *args, PyObject *kw)
 	struct cmsghdr *cmsg;
 	PyObject *buf;
 	int numfds = 32;
-	int fd, r, flags = 0;
+	int fd, flags = 0;
+	size_t r;
 	int msg_len;
 	PyObject *ret = NULL;
 

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,10 @@
 
 import sys
 
-try:
-    from setuptools import setup
-    setupopts = {
-            'test_suite':"fdsend.tests",
-        }
-    if sys.version_info >= (3,):
-        setupopts['use_2to3'] = True
-except ImportError:
-    from distutils.core import setup
-    setupopts = {}
+from setuptools import setup
+setupopts = {
+        'test_suite':"fdsend.tests",
+}
 from distutils.extension import Extension
 
 setup(


### PR DESCRIPTION
This also fixes a compiler warning and breakage in setup.py when 2to3 is requested.